### PR TITLE
docs: adding prelminary local mac setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ Quick instructions for getting started if you're on Mac OSX.
 - Brew installed
 - NodeJS installed
 
-```shell
+### CLI Instructions
 
-# Installs the Hugo Binrary that will be used to build and run the Hugo Server
+These are the step-by-step instructions one can execute to configure a local environment.
+
+```shell
+# Installs the Hugo Binary that will be used to build and run the Hugo Server
 brew install hugo
 
 # Clone the repo locally

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # website-hugo
+
 Hugo based website for the project.
+
+## Setup Local Environment
+
+Quick instructions for getting started if you're on Mac OSX.
+
+### Requirements
+
+- Brew installed
+- NodeJS installed
+
+```shell
+
+# Installs the Hugo Binrary that will be used to build and run the Hugo Server
+brew install hugo
+
+# Clone the repo locally
+git clone git@github.com:thegooddocsproject/website-hugo.git
+
+# Enter the default working path
+cd website-hugo
+
+# Configure the remote sub-module where the docsy theme is store
+git submodule add https://github.com/google/docsy.git themes/docsy
+
+# Pulls down the latest from docsy theme
+git submodule update --init --recursive
+
+# Installs the CSS processor
+npm install
+
+# Run the build process/http service
+hugo server
+```
+


### PR DESCRIPTION
## Issue 

View Issue: #4 

## Purpose / why

I wanted to run the project locally, and in setting it up I added preliminary instructions for configuring on a mac.

## What changes were made?

Specifically added a local-setup block of text on the Readme.

## Verification

View the updated [README](https://github.com/thegooddocsproject/website-hugo/blob/morgan/setup-local-dev-instructions/README.md)

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Are issues linked correctly?
* [x] Is this PR labeled correctly?
* [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
* [ ] On merging, did you add any applicable notes to a [draft release](https://github.com/thegooddocsproject/templates/releases) and link to this PR?
