### PR TITLE
fix: adjusting themes/docsy gitlink for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# website-hugo
+# The Good Docs Marketing Site
 
 Hugo based website using the [docsy](https://github.com/google/docsy/) theme.
 

--- a/README.md
+++ b/README.md
@@ -20,16 +20,10 @@ These are the step-by-step instructions one can execute to configure a local env
 brew install hugo
 
 # Clone the repo locally
-git clone git@github.com:thegooddocsproject/website-hugo.git
+git clone --recurse-submodules --depth 1 git@github.com:thegooddocsproject/website-hugo.git
 
 # Enter the default working path
 cd website-hugo
-
-# Configure the remote sub-module where the docsy theme is store
-git submodule add https://github.com/google/docsy.git themes/docsy
-
-# Pulls down the latest from docsy theme
-git submodule update --init --recursive
 
 # Installs the CSS processor
 npm install
@@ -37,4 +31,3 @@ npm install
 # Run the build process/http service
 hugo server
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # website-hugo
 
-Hugo based website for the project.
+Hugo based website using the [docsy](https://github.com/google/docsy/) theme.
 
 ## Setup Local Environment
 


### PR DESCRIPTION
## Issue

Part of #6 -- When the repo was first cloned `themes/` weren't being ignored as part of `git submodules`.

## Purpose / why

As discussed on slack with @bwklein about the above issue it was indicated that by default `themes/docsy` is a `git-submodule` and by default should be `ignored`.  This prompted an investigation to understand why there was this discrepancy.

It was also pointed out that the cloning of the repository using

```shell
git clone --recurse-submodules --depth 1 git@github.com:thegooddocsproject/website-hugo.git
```

Was not working properly to clone the repo with the submodules for themes already populated.

## Implementation

### Docsy A Base Case

As a basis for investigating, we used the official Docsy repo as a test-case because it includes [git-submodules](https://github.com/google/docsy/blob/master/.gitmodules).

```shell
# .gitmodules
[submodule "assets/vendor/bootstrap"]
	path = assets/vendor/bootstrap
	url = https://github.com/twbs/bootstrap.git
[submodule "assets/vendor/Font-Awesome"]
	path = assets/vendor/Font-Awesome
	url = https://github.com/FortAwesome/Font-Awesome.git
```

And if one inspects the repo further the [assets/vendor/ folder](https://github.com/google/docsy/tree/master/assets/vendor)

![Screen Shot 2020-11-05 at 12 13 22 PM](https://user-images.githubusercontent.com/89339/98294237-9d939500-1f7d-11eb-8d22-ce10510485be.png)
_These are the `gitlinks` formed for the submodule_


### Diving into Git SubModules

In order for `themes/docsy` to be ignored we need to configure the submodule as documented: [Official Docs: git-submodules](https://git-scm.com/docs/gitsubmodules)

> Assuming the submodule has a Git directory at `$GIT_DIR/modules/foo/` and a working directory at `path/to/bar/`, the superproject tracks the submodule via a `gitlink` entry in the tree at `path/to/bar` and an entry in its `.gitmodules` file (see gitmodules[5]) of the form `submodule.foo.path = path/to/bar`.

> The `gitlink` entry contains the object name of the commit that the superproject expects the submodule’s working directory to be at.

By running the following CLI command locally

```shell
git submodule add -b master https://github.com/google/docsy.git themes/docsy
```

This updated the current `.gitmodules` to include `branch=master` and it also created the `gitlink` at `theme/docsy` which became changed-files for the repo.

```shell

$ git status
On branch main
Your branch is up to date with 'origin/main'.
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   .gitmodules
	new file:   themes/docsy
```



## Verification

There are a few ways to verify the work.

__1. Clone Repo using this branch__

Running the following clone command will target this `branch` and will do a full clone including the `gitsubmodule(s)`.

```shell
$ git clone --recurse-submodules --depth 1 -b testing git@github.com:thegooddocsproject/website-hugo.git

Cloning into 'website-hugo'...
remote: Enumerating objects: 68, done.
remote: Counting objects: 100% (68/68), done.
remote: Compressing objects: 100% (47/47), done.
remote: Total 68 (delta 9), reused 62 (delta 9), pack-reused 0
Receiving objects: 100% (68/68), 887.91 KiB | 5.92 MiB/s, done.
Resolving deltas: 100% (9/9), done.
Submodule 'themes/docsy' (https://github.com/google/docsy.git) registered for path 'themes/docsy'
Cloning into '/Users/morgancraft/Documents/projects/website-hugo/themes/docsy'...
remote: Enumerating objects: 4203, done.
remote: Total 4203 (delta 0), reused 0 (delta 0), pack-reused 4203
Receiving objects: 100% (4203/4203), 7.58 MiB | 13.04 MiB/s, done.
Resolving deltas: 100% (2363/2363), done.
Submodule path 'themes/docsy': checked out 'e67775a312f1f3ad32137423fe2b311a397f5293'
Submodule 'assets/vendor/Font-Awesome' (https://github.com/FortAwesome/Font-Awesome.git) registered for path 'themes/docsy/assets/vendor/Font-Awesome'
Submodule 'assets/vendor/bootstrap' (https://github.com/twbs/bootstrap.git) registered for path 'themes/docsy/assets/vendor/bootstrap'
Cloning into '/Users/morgancraft/Documents/projects/website-hugo/themes/docsy/assets/vendor/Font-Awesome'...
remote: Enumerating objects: 1722, done.
remote: Counting objects: 100% (1722/1722), done.
remote: Compressing objects: 100% (1668/1668), done.
remote: Total 28941 (delta 220), reused 179 (delta 53), pack-reused 27219
Receiving objects: 100% (28941/28941), 62.32 MiB | 24.84 MiB/s, done.
Resolving deltas: 100% (21512/21512), done.
Cloning into '/Users/morgancraft/Documents/projects/website-hugo/themes/docsy/assets/vendor/bootstrap'...
remote: Enumerating objects: 21, done.
remote: Counting objects: 100% (21/21), done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 135767 (delta 0), reused 18 (delta 0), pack-reused 135746
Receiving objects: 100% (135767/135767), 138.22 MiB | 28.75 MiB/s, done.
Resolving deltas: 100% (90809/90809), done.
Submodule path 'themes/docsy/assets/vendor/Font-Awesome': checked out '951a0d011f8c832991750c16136f8e260efa60b5'
remote: Enumerating objects: 1107, done.
remote: Counting objects: 100% (1107/1107), done.
remote: Total 3616 (delta 1107), reused 1107 (delta 1107), pack-reused 2509
Receiving objects: 100% (3616/3616), 5.33 MiB | 14.92 MiB/s, done.
Resolving deltas: 100% (2504/2504), completed with 348 local objects.
From https://github.com/twbs/bootstrap
 * branch                a716fb03f965dc0846df479e14388b1b4b93d7ce -> FETCH_HEAD
Submodule path 'themes/docsy/assets/vendor/bootstrap': checked out 'a716fb03f965dc0846df479e14388b1b4b93d7ce'
```

__2. Verify using git cli__

There are additionally two ways to inspect the git-submodules.

```shell
# 160000 is a special file type for gitlink

$ git ls-tree HEAD themes/docsy

160000 commit e67775a312f1f3ad32137423fe2b311a397f5293	themes/docsy
```

One can also run the generic `git submodule` and see a listing of all submodules.

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Are issues linked correctly?
* [x] Is this PR labeled correctly?
* [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
* [ ] On merging, did you add any applicable notes to a [draft release](https://github.com/thegooddocsproject/templates/releases) and link to this PR?
