### PR TITLE
adding press page with redirect

### DIFF
--- a/content/en/press/_index.md
+++ b/content/en/press/_index.md
@@ -1,0 +1,32 @@
+---
+title: Press The Good Docs Project
+linkTitle: Press
+menu:
+  main:
+    weight: 20
+aliases:
+    - /press.html
+---
+{{% blocks/lead color="primary" %}}
+
+# Press The Good Docs Project
+
+Read the latest news and headlines regarding The Good Docs Project and how our best practice templates and writing instructions empowers people to document Open Source Software.
+
+{{% /blocks/lead %}}
+
+{{% blocks/section color="white" type="section" %}}
+
+## Featured Press
+
+* __2020-11-17__ - [Documentation templates and The Good Docs Project](https://idratherbewriting.com/blog/documentation-templates-good-docs-project/): Ankita Tripathi's journey into The Good Docs Project.
+* __2020-09-22__ - "Tech Writing Patterns and Anti-Patterns", and how these are getting tackled by The Good Docs Project. Presented at Write the Docs Australia virtual meetup by Cameron Shorter: [Video](https://www.youtube.com/watch?v=yiGFbXYyCr0&feature=youtu.be) and [slides](https://docs.google.com/presentation/d/1yFJ2WL-l8O1vnNR67bFfmzHu6tyJjtkJD-cSyH3mNes/).
+* __2020-09-18__ - [Google's Open Source Peer Bonus awards for Jared Morgan and Jo Cook](http://cameronshorter.blogspot.com/2020/09/awards-for-open-source-tech-writers.html).
+* __2020-05-27__ - Article about Felicity, including [her involvement in TheGoodDocsProject](https://typo3.org/article/typo3-book-report-whos-writing-the-typo3-book).
+* __2020-04-24__ - "Documentation Templates for Fun & Profit". Presentation by Erin McKean, followed by audience discussion, at Write the Docs San Francisco. [Video](https://www.youtube.com/watch?v=FaJIAorSb34).
+* __2020-03-12__ - Insights from involvement in [Season of Docs 2019](http://cameronshorter.blogspot.com/2020/03/insights-from-mixing-writers-with-open.html).
+* __2019-12-16__ - Announcing TheGoodDocsProject at the Developer Relations Conference in London. Jo Cook's [blog post](https://archaeogeek.com/blog/2019/12/15/devrelcon2019/), her [slides](https://github.com/archaeogeek/devrelcon2019), and [conference recording](https://devrel.net/developer-experience/inspiring-and-empowering-users-to-become-great-writers-and-why-thats-important).
+* __2019-11-25__ - Launching TheGoodDocsProject at WriteTheDocs - Australia conference (and conference highlights) [Cameron Shorter's blog post](http://cameronshorter.blogspot.com/2019/11/launching-thegooddocsproject.html).
+* __2019-11-11__ - [Announcement-1](https://github.com/thegooddocsproject/governance/wiki/Announcement-1) Fixit Workshop, at WriteTheDocs - Australia conference.
+
+{{% /blocks/section %}}

--- a/content/en/press/_index.md
+++ b/content/en/press/_index.md
@@ -4,8 +4,6 @@ linkTitle: Press
 menu:
   main:
     weight: 20
-aliases:
-    - /press.html
 ---
 {{% blocks/lead color="primary" %}}
 


### PR DESCRIPTION
## Issue

- Issue #15 

## Purpose / why

Porting over the Press page as part of the initial migration.

## What changes were made?

Made a new folder `press` and added the `_index.md`.  Lifted the template from __About__ and made some modifications and then inserted the `markdown` from the `press.md` file in the jekyll repo.

Also added the `aliases` to include a redirect for `press.html`.

Made some tweaks to the copy and added some __bold__ to the dates to give the section more contrast

## Verification

I've forked the repo now so to do a review:

1. `git add remote morgan https://github.com/mgan59/website-hugo.git` __OR__ `git add remote morgan git@github.com:mgan59/website-hugo.git`
2. `git fetch --all`
3. `git checkout morgan/adding-press-page`
4. `hugo server`

Goto Press Page and should see

![Screen Shot 2020-11-28 at 6 47 14 AM](https://user-images.githubusercontent.com/89339/100514899-66f90680-3146-11eb-8934-7e3bb4efcc52.png)


---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Are issues linked correctly?
* [x] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
