### PR TITLE
Minor syntax edits to Home page.

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -5,6 +5,7 @@ linkTitle: "Home"
 ---
 
 {{< blocks/cover title="The Good Docs Project" image_anchor="top" height="max" color="orange" >}}
+
 <div class="mx-auto">
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/about">
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
@@ -15,15 +16,18 @@ linkTitle: "Home"
 	<p class="lead mt-5">Templates to make good docs.</p>
 	{{< blocks/link-down color="info" >}}
 </div>
+
 {{< /blocks/cover >}}
 
 
 {{% blocks/lead color="primary" %}}
+
 Best practice templates and writing instructions for documenting open source software.
+
 {{% /blocks/lead %}}
 
 
-{{< blocks/section type="section" color="white" >}}
+{{% blocks/section type="section" color="white" %}}
 
 ## Why?
 We want to help open source projects be more effective by helping them lift the quality of their documentation.
@@ -41,7 +45,7 @@ Our key target audiences are:
 * Technical writers setting up a documentation framework, who want to make use of established templates and processes, customizing where appropriate to align with the project's goals.
 * Project owners who need to balance project priorities, and want to understand the return-on-effort associated with different documentation strategies.
 
-{{< /blocks/section >}}
+{{% /blocks/section %}}
 
 
 {{% blocks/section type="section" %}}
@@ -50,6 +54,7 @@ Our key target audiences are:
 
 * The latest development version of templates are available from the [github main branch](https://github.com/thegooddocsproject/templates).
 * The [0.1 alpha straw-man release of templates](https://github.com/thegooddocsproject/templates/releases/tag/v0.1) was released at the 2019 Write The Docs - Australia conference.
+
 {{% /blocks/section %}}
 
 

--- a/content/en/community/index.md
+++ b/content/en/community/index.md
@@ -60,6 +60,7 @@ We are nice to each other, in line with our [Code of Conduct](https://github.com
 
 ## Additional Resources and Information
 
+* [Who We Are](/who-we-are)
 * [How to Contribute](/contribute)
 * [Roles and responsibilities](/roles)
 * Decisions

--- a/content/en/roles/index.md
+++ b/content/en/roles/index.md
@@ -150,7 +150,7 @@ We, the Project Steering Committee of The Good Docs Project, have been impressed
 To accept, could you please reply publicly to this email list confirming:
 1. You would like to accept the role.
 1. You feel you meet the eligibility criteria, including your intent to continue participating in this project for a while.
-1. You accept the responsibilities associated with the role, as described in https://thegooddocsproject.dev/roles/.
+1. You accept the responsibilities associated with the role, as described on the [Roles](/roles) page.
 
 Regards,
 

--- a/content/en/roles/index.md
+++ b/content/en/roles/index.md
@@ -1,0 +1,166 @@
+---
+title: Roles
+
+---
+
+{{% blocks/lead color="primary" %}}
+
+# Roles
+
+Here we define roles within The Good Docs Project, along with the eligibility, expectations, and responsibilities associated with these roles.
+
+**Version:** 2.0.1 - **Last updated:** September 2020
+
+{{% /blocks/lead %}}
+
+{{% blocks/section color="white" type="section" %}}
+
+## Community
+
+Everyone contributing to, or using artifacts from, The Good Docs Project is considered part of our community. We encourage all community members to actively participate in our activities. This includes:
+
+*   Participate in our forums and vote on motions.
+*   Raise and comment on issues.
+*   Suggest fixes by raising pull requests.
+*   Comment on and review pull requests.
+
+### Access:
+
+*   Community members have _read_ access to our github repositories (by default).
+
+### Expectations of community members:
+
+*   Community members are expected to be respectful to each other, in line with our [Code of Conduct](https://github.com/thegooddocsproject/governance/blob/master/CodeOfConduct.md).
+
+## Committers
+
+A committer is a trusted community member who has additionally been given _write_ access to some or all of our github repositories.
+
+[Current committers](/who-we-are)
+
+### Access:
+
+*   Committers are granted _triage_, _maintain_ and _write_ access to the github repositories which they have contributed to.
+
+### Additional expectations of committers:
+
+*   Understand and apply our quality guidelines.
+*   Understand and abide by our license requirements.
+*   Periodically contribute to our project over a one year period.
+
+### Eligibility:
+
+Before being accepted for this role, a person should display the following characteristics:
+
+*   Provide sustained, valuable contributions to the project, typically for three months or more. An example demonstration of this could be:
+    *   Submit pull requests which have been accepted and merged by other committers. Typically one large, three medium, or five small pull requests over three months.
+    *   Or provide equivalent contributions to our community, such as outreach, contributing to our forums, or coordinating activities. 
+*   Express an interest in ongoing participation.
+*   Acknowledge the committer expectations.
+
+## Project Steering Committee
+
+The Project Steering Committee (PSC) is the official managing body for our project. The committee is drawn from the community and is based on merit and interest.
+
+*   We aim to attract a diverse mix of personal characteristics, reflective of the community we represent.
+*   We wish to avoid having employees of any one organisation representing a controlling proportion of the PSC.
+
+A PSC chair shall be selected from the PSC, with the only official extra duty being that they have a deciding vote in the case of a tie.
+
+[Current PSC members](/who-we-are)
+
+### Access:
+
+*   PSC members may be granted admin access to our github repositories if they have a need for them.
+
+### Additional expectations of PSC members:
+
+*   Consider opinions from within our community, and advocate for the best interests of our community when making decisions.
+*   Vote according to your personal best judgment, as opposed to voting on behalf of your employer.
+*   Vote promptly (usually within days) to motions being raised.
+*   Regularly participate in project activities.
+*   Help with whatever unglamorous work that is required to keep the project moving forward.
+*   Monitor conversations within our forums and contribute constructively where appropriate.
+*   Optionally attend weekly meetings.
+
+### Eligibility:
+
+Before being accepted for this role, a person should display the following characteristics:
+
+*   Sustained track record displaying the characteristics expected of PSC members, typically while acting as a committer within our project, typically for six months or more.
+*   Express an interest in ongoing participation.
+*   Acknowledge the PSC member expectations.
+
+## Mentors
+
+Initiatives which are funded by The Good Docs Project should have a mentor.
+
+[Current mentors](/who-we-are)
+
+### Expectations of mentors:
+
+A mentor’s responsibilities typically includes:
+
+*   Mentor a worker in developing a proposal.
+*   Facilitate making connections with other members within the community.
+*   Attend weekly meetings and provide guidance where applicable.
+*   If needed, escalate concerns to the Project Steering Committee.
+*   Review work done, and recommend the approval or rejection of the project based on work done.
+
+### Eligibility:
+
+A mentor will typically be a member of the PSC, but may be an experienced person who is trusted by the PSC.
+
+Any conflict-of-interest the mentor may have should be stated beforehand. This could result from mentoring managers, direct reports, relatives, or close friends. The PSC will need to decide whether the conflict will negatively impact the mentoring experience.
+
+## Treasurers
+
+Treasurers are PSC members who additionally have been provided with admin access to our [financial account with Open Collective](https://opencollective.com/thegooddocsproject).
+
+[Current treasurers](/who-we-are)
+
+### Expectations of treasurers:
+
+*   Notify the PSC of Open Collective funding requests by [raising a motion](/decisions).
+*   AFTER receiving approval from the PSC, approve funding requests.
+
+### Eligibility:
+
+In order to limit the risk of misappropriation of funds, financial approval privileges should only be provided to a few long serving PSC members.
+
+# Selection of roles
+
+*   The PSC will review roles at least annually, in March, with the aims of:
+    *   Inviting active and eligible community members into relevant roles, based on our eligibility criteria.
+    *   Moving people who have been inactive for a year into a retired status, with thanks.
+    *   Selecting a PSC chair.
+*   Ad-hoc invitations may be initiated throughout the year, as needed.
+*   Retired members should expect to be welcomed back if they become active again.
+*   PSC discussions about membership will typically be conducted privately in order to respect the feelings of those being discussed.
+*   PSC selection decisions will follow our decision making process.
+
+## Invitation email
+
+_This example email can be customized to be made personal_.
+
+Hi \[Name],
+
+We, the Project Steering Committee of The Good Docs Project, have been impressed with your contributions to The Good Docs Project, and would like to invite you to take up our official role of \[Role].
+
+To accept, could you please reply publicly to this email list confirming:
+1. You would like to accept the role.
+1. You feel you meet the eligibility criteria, including your intent to continue participating in this project for a while.
+1. You accept the responsibilities associated with the role, as described in https://thegooddocsproject.dev/roles.html.
+
+Regards,
+
+\[Name], on behalf of the PSC
+
+## Next steps
+* Wait untill the person accepts the invitation.
+* Add the person's name to the [/who-we-are](/who-we-are) page.
+* Update our decision register, as per our [decisions](/decisions) process.
+* Add person to appropriate teams in [GitHub](https://github.com/orgs/thegooddocsproject/teams).
+
+
+{{% /blocks/section %}}

--- a/content/en/roles/index.md
+++ b/content/en/roles/index.md
@@ -158,7 +158,7 @@ Regards,
 
 ## Next steps
 * Wait untill the person accepts the invitation.
-* Add the person's name to the [/who-we-are](/who-we-are) page.
+* Add the person's name to the [Who We Are](/who-we-are) page.
 * Update our decision register, as per our [decisions](/decisions) process.
 * Add person to appropriate teams in [GitHub](https://github.com/orgs/thegooddocsproject/teams).
 

--- a/content/en/roles/index.md
+++ b/content/en/roles/index.md
@@ -150,7 +150,7 @@ We, the Project Steering Committee of The Good Docs Project, have been impressed
 To accept, could you please reply publicly to this email list confirming:
 1. You would like to accept the role.
 1. You feel you meet the eligibility criteria, including your intent to continue participating in this project for a while.
-1. You accept the responsibilities associated with the role, as described in https://thegooddocsproject.dev/roles.html.
+1. You accept the responsibilities associated with the role, as described in https://thegooddocsproject.dev/roles/.
 
 Regards,
 

--- a/content/en/who-we-are/index.md
+++ b/content/en/who-we-are/index.md
@@ -1,0 +1,59 @@
+---
+title: Who We Are
+
+---
+
+{{% blocks/lead color="primary" %}}
+
+# Who We Are
+Here we list the people behind this project, as defined by the project's [roles](/roles).
+
+{{% /blocks/lead %}}
+
+
+{{% blocks/section color="white" type="section" %}}
+
+## Project Steering Committee (PSC)
+
+* Cameron Shorter, chair
+* Felicity Brand
+* Jared Morgan
+* Erin McKean
+* Clarence Cromwell
+* Morgan Craft
+* Alyssa Rock
+
+Our thanks to previous PSC members:
+
+* Jo Cook
+* Jennifer Rondeau
+* Becky Todd
+
+## Committers
+
+* Lana Brindley
+* Daniel Beck
+* Aidan Doherty
+* Viraji Ogodapola
+* Aaron Peters
+
+Our thanks to previous committers:
+
+* \<None yet\>
+
+## Mentors
+Informal and semi-formal mentoring is a natural part of our community which we encourage and enjoy.
+Here we list formal mentoring which has been set up as part of our [proposal selection](/proposal-selection) process:
+
+* Jared Morgan
+* Clarence Cromwell
+
+Our thanks to previous mentors:
+
+* \<None yet\>
+
+## Treasurers
+
+* \<Still to be officially endorsed\>
+
+{{% /blocks/section %}}


### PR DESCRIPTION
closes #19, closes #20 

## Purpose / why

Continued migration of the site, and page clean up for Hugo.

## What changes were made?

Migrated "Roles" and "Who We Are" pages.  Also updated the syntax on the Home page and moved the Community page into a folder instead of a standalone file, like the other pages are setup.

## Verification

Check the new /roles and /who-we-are pages.
