### PR TITLE
Migrate decisions log page to section of decisions page.

### DIFF
--- a/content/en/decisions/index.md
+++ b/content/en/decisions/index.md
@@ -46,6 +46,12 @@ A motion is considered passed when there are more PSC +1 votes than -1 votes, an
 ## Record decisions
 
 *   All decisions should be captured in meeting minutes or forwarded to our email list. 
-*   Results of significant decisions should be copied into our [decision register](https://github.com/thegooddocsproject/governance/wiki/Decision-Log-2020).
+*   Results of significant decisions should be copied into our current [decision register](https://github.com/thegooddocsproject/governance/wiki/Decision-Log-2021).
+
+## Project Decision Log Archives
+
+[Decision Log 2020](https://github.com/thegooddocsproject/governance/wiki/Decision-Log-2020)
+
+[Decision Log 2019](https://github.com/thegooddocsproject/governance/wiki/Decision-Log-2019)
 
 {{% /blocks/section %}}


### PR DESCRIPTION
Resolves #23 

## Purpose / why

Move the Decision Log page into an archive section of the Decisions page.

## What changes were made?

Added a section and links to the bottom of the decisions page.
