### PR TITLE
feat: ported licenses content

### DIFF
--- a/content/en/licenses/index.md
+++ b/content/en/licenses/index.md
@@ -1,0 +1,31 @@
+---
+title: Licenses
+linkTitle: Licenses
+menu:
+  main:
+    weight: 30
+---
+
+{{% blocks/section color="white" type="section" %}}
+
+# License of Templates: 0BSD
+
+In order to facilitate maximum reusability, artifacts provided in *The Good Docs Project* templates repository are dedicated to the public domain, as per the [Zero-Clause BSD license](https://opensource.org/licenses/0BSD). These artifacts are permitted to be incorporated into any other licenced work.
+
+While not mandated, we do appreciate being acknowledged. Hopefully you will help others find our project using a statement like:
+
+“This documentation is based on templates from [The Good Docs Project](https://thegooddocsproject.dev/).”
+
+## License of supporting docs and website: CC-By
+
+*The Good Docs Project* website, along with supporting documentation for the template artifacts, are licensed under a [Creative Commons By Attribution License (CC-By 4.0)](https://creativecommons.org/licenses/by/4.0/).
+
+You can attribute documentation using a statement similar to:
+
+“This document [is derived from \| includes \| extends] documentation from [The Good Docs Project](https://thegooddocsproject.dev/).”
+
+## Contributor Agreement
+
+By contributing to this project, contributors agree to provide their contributions in line with the project’s licenses, as per the [Developer Certificate of Origin statement version 1.0](https://developercertificate.org/).
+
+{{% /blocks/section %}}


### PR DESCRIPTION
## Purpose / why

Based on Issue #24.  Completed the initial porting of just the `markdown` as is into the Hugo site.  There were some discussions around if we were sticking with `0BSD` which we are, but we should include it in it's full-text within our template site.  But that could be a followup.

## Verification

<details>
<summary>Visuals</summary>


![Screen Shot 2021-02-10 at 6 11 42 PM](https://user-images.githubusercontent.com/89339/107585048-8642f400-6bcb-11eb-9e52-8a474e24753f.png)


</details>


## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Are issues linked correctly?
* [x] Is this PR labeled correctly?
* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?

