### PR TITLE
add Base Template Working Group page

### DIFF
--- a/content/en/working-group/base-template.md
+++ b/content/en/working-group/base-template.md
@@ -1,0 +1,22 @@
+---
+title: Base Template
+poc: "[Aidan Doherty](https://thegooddocs.slack.com/team/U019868JEQ0)"
+meeting: Once per week (on Google Meet).
+status: Active
+description: Use the base template to create new doctype templates; apply insights from that process to improve the base template.
+slackName: base-template
+slackID: C01T803GT34
+notesURL: https://docs.google.com/document/d/1jKFy7rQ7Rv4nP797cwuLssrbplFQ2ZIM_XewsV0Xj1Q/edit#
+members:
+  - "[Aidan Doherty](https://thegooddocs.slack.com/team/U019868JEQ0)"
+  - "[Alyssa Rock](https://thegooddocs.slack.com/team/U012KCMPP0V)"
+  - "[cameronshorter](https://thegooddocs.slack.com/team/UKTGLQNGG)"
+  - "[macklin](https://thegooddocs.slack.com/team/U01DYRWG43X)"
+draft: false
+---
+
+A key initiative for The Good Docs Project is creating doctype templates that can be used to quickly and easily create documentation. For this working group, we are looking for technical writers and other interested folks who want to collaborate on creating the ideal page structure for different types of doc pages. 
+
+We plan to use the base template (a "template of templates") that we've created as the starting point for this work. We also take inspiration from the doc types in the Divio Documentation System. Join this group to get your hands dirty on the content/editorial side of the project. We will divide up the remaining tasks to write new templates.
+
+Our primary goal is to finalize enough templates to power a demo at an upcoming conference.

--- a/content/en/working-group/base-template.md
+++ b/content/en/working-group/base-template.md
@@ -15,7 +15,8 @@ members:
 draft: false
 ---
 
-A key initiative for The Good Docs Project is creating doctype templates that can be used to quickly and easily create documentation. For this working group, we are looking for technical writers and other interested folks who want to collaborate on creating the ideal page structure for different types of doc pages. 
+A key initiative for The Good Docs Project is creating doctype templates that can be used to quickly and easily create documentation.
+For this working group, we are looking for technical writers and other interested folks who want to collaborate on creating the ideal page structure for different types of doc pages. 
 
 We plan to use the base template (a "template of templates") that we've created as the starting point for this work. We also take inspiration from the doc types in the Divio Documentation System. Join this group to get your hands dirty on the content/editorial side of the project. We will divide up the remaining tasks to write new templates.
 


### PR DESCRIPTION
## Purpose / why

This PR adds a working group detail page for the Base Template Working Group. Fixes [issue 52](https://github.com/thegooddocsproject/website-hugo/issues/52).

## What changes were made?

Used the new template to create a new markdown page in the working-group directory.

## Verification

Take a look at the "working-group/base-template" page on local build of site and see if you approve of it.

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Are issues linked correctly?
* [ ] Is this PR labeled correctly?
* [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
* [ ] On merging, did you add any applicable notes to a [draft release](https://github.com/thegooddocsproject/templates/releases) and link to this PR?
