### PR TITLE
Add group description for the community docs working group

### DIFF
--- a/content/en/working-group/community-docs.md
+++ b/content/en/working-group/community-docs.md
@@ -1,0 +1,22 @@
+---
+title: Community Docs
+poc: "[Alyssa Rock](https://thegooddocs.slack.com/team/U012KCMPP0V)"
+meeting: Thursdays at 5:00p Mountain time (UTC-6)
+status: Active
+description: Creating high-quality templates for the core sets of community docs that are necessary for the health, productivity, and cross-coordination of open source communities.
+slackName: community-docs
+slackID: C01R89CRWCR
+notesURL: https://docs.google.com/document/d/1iRxB0T7FoVjIeG_LawbCzcLfXCILlpFdzn-4BPDGR9Y/edit?usp=sharing
+members:
+  - "[Alyssa Rock](https://thegooddocs.slack.com/team/U012KCMPP0V)"
+  - "[Carrie Crowe](https://thegooddocs.slack.com/team/U01QS8YAHHN)"
+  - "[Daniel Beck](https://thegooddocs.slack.com/team/U011GCVJFQF)"
+  - "[Erin McKean](https://thegooddocs.slack.com/team/UL2AA1FF1)"
+  - "[Felicity Brand](https://thegooddocs.slack.com/team/UKV4ZPEFQ)"
+  - "[Sachin Karol](https://thegooddocs.slack.com/team/U015ZA95M7S)"
+draft: false
+---
+
+Every open source community should have some core community documentation like a good README, Contributing Guide, PR and issue templates, Code of Conduct, RFCs, and more. This working group is collaborating together to provide high-quality templates and best practices for the types of documentation your project needs to attract and retain active contributors.
+
+If you're passionate about creating healthy open source communities and ensuring everyone who joins a community can find a meaningful way to start contributing as soon as possible, then this is the working group for you!


### PR DESCRIPTION
## Purpose / why

This PR adds the description page for the community docs working group.

## What changes were made?

This adds a new file to the working groups section of the website.

## Verification

Check that it is well-worded and verify that the information is accurate.

---

## Checklist

* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
* [ ] On merging, did you add any applicable notes to a [draft release](https://github.com/thegooddocsproject/templates/releases) and link to this PR?
