### PR TITLE
Update Who We Are page to reflect latest changes

### DIFF
--- a/content/en/who-we-are.md
+++ b/content/en/who-we-are.md
@@ -16,28 +16,29 @@ TheGoodDocsProject Project Steering Committee (PSC) is the official managing bod
 
 ## PSC Members
 
--   Cameron Shorter, chair
+-   Alyssa Rock, chair
 -   Aaron Peters
 -   Aidan Doherty
--   Alyssa Rock
 -   Ankita Tripathi
 -   Bryan Klein
--   Clarence Cromwell
+-   Cameron Shorter
 -   Erin McKean
 -   Morgan Craft
 -   Viraji Ogodapola
 
 Our thanks to previous PSC members:
 
--   Jennifer Rondeau
 -   Becky Todd
--   Jo Cook
--   Jared Morgan
+-   Clarence Cromwell
 -   Felicity Brand
+-   Jared Morgan
+-   Jennifer Rondeau
+-   Jo Cook
 
 ## Committers
 
 -   Chris Ward
+-   Clarence Cromwell
 -   Daniel Beck
 -   Derek Ardolf
 -   Felicity Brand


### PR DESCRIPTION
## Purpose / why

I noticed that our Who We Are page doesn't reflect the recent changes to roles that we have on our governance page: https://github.com/thegooddocsproject/governance/blob/master/ProjectSteeringCommittee.md

## What changes were made?

Mostly I'm just syncing this page to make sure it reflects what is on the governance repo. FYI, Cameron thinks we should retire the governance repo and just use the website repo as the source of truth. I'd be interested in thoughts on that.