### PR TITLE
Add Cafe Procope working group details (docs advocacy and education)

### DIFF
--- a/content/en/working-group/community-docs.md
+++ b/content/en/working-group/community-docs.md
@@ -17,6 +17,7 @@ members:
 draft: false
 ---
 
-Every open source community should have some core community documentation like a good README, Contributing Guide, PR and issue templates, Code of Conduct, RFCs, and more. This working group is collaborating together to provide high-quality templates and best practices for the types of documentation your project needs to attract and retain active contributors.
+Every open source community should have some core community documentation like a good README, Contributing Guide, PR and issue templates, Code of Conduct, RFCs, and more.
+This working group is collaborating together to provide high-quality templates and best practices for the types of documentation your project needs to attract and retain active contributors.
 
 If you're passionate about creating healthy open source communities and ensuring everyone who joins a community can find a meaningful way to start contributing as soon as possible, then this is the working group for you!

--- a/content/en/working-group/docs-advocacy-and-education.md
+++ b/content/en/working-group/docs-advocacy-and-education.md
@@ -1,0 +1,19 @@
+---
+title: Procope
+poc: "[Ryan Macklin](https://thegooddocs.slack.com/team/U01DYRWG43X)"
+meeting: Still being determined; come join and help us decide!
+status: Active
+description: Generating videos, blog entries, and other media to promote greater empathy for documentation readers and share best practices for documentation creators.
+slackName: cafe-procope
+slackID: C01SDNR5X1C
+notesURL: http://bit.ly/gcp-procope-meeting
+members:
+ - "[Aaron Peters](https://thegooddocs.slack.com/team/U013XPC8Q9Z)"
+ - "[Alyssa Rock](https://thegooddocs.slack.com/team/U012KCMPP0V)"
+ - "[Ryan Macklin](https://thegooddocs.slack.com/team/U01DYRWG43X)"
+ - "[Carrie Crowe](https://thegooddocs.slack.com/team/U01QS8YAHHN)"
+draft: false
+---
+Our group's mission statement: Educating the public on strong documentation philosophies and practices, to empower those who aren't primarily tech writers (and also those who are). One part of improving docs in open source is getting buy-in from developers about why docs matter. Another part is helping people interested in good documentation learn how to create it!
+
+Join this group if you’re interested in working on videos, scripts, blog entries, white papers, or any other kind of media that will promote documentation fundamentals and best practices. Our group's working model is largely distributed efforts to create content, brought together in review and scheduled by one of the lead publishers. We're looking for people who want to offer doc advocacy and practices, or who want to learn those things and be involved with critiquing submitted content.


### PR DESCRIPTION
## Purpose / why

This PR adds the working group details for the Cafe Procope working group (docs advocacy and education).

## What changes were made?

Adds a new page to the working groups section.