### PR TITLE
Remove target _blank from community links list.

### DIFF
--- a/layouts/shortcodes/blocks/community_links.html
+++ b/layouts/shortcodes/blocks/community_links.html
@@ -24,7 +24,7 @@
 <ul style="list-style:none; padding-left:0;">
  {{ range . }}
  <li title="{{ .name }}">
-   <a target="_blank" href="{{ .url }}"><i class="{{ .icon }}"></i>&nbsp;&nbsp;{{ .name }}:</a> {{ .desc }}
+   <a href="{{ .url }}"><i class="{{ .icon }}"></i>&nbsp;&nbsp;{{ .name }}:</a> {{ .desc }}
  </li>
   {{ end }}
 </ul>


### PR DESCRIPTION
Stop opening links in a new tab.