### PR TITLE
Add Content Strategy working group details

### DIFF
--- a/content/en/working-group/content-strategy.md
+++ b/content/en/working-group/content-strategy.md
@@ -1,0 +1,24 @@
+---
+title: Content Strategy
+poc: "[Carrie Crowe](https://thegooddocs.slack.com/team/U01QS8YAHHN)"
+meeting: TBD
+status: Active
+description: Creating
+slackName: content-strategy
+slackID: C023G344YAJ
+notesURL: https://docs.google.com/document/d/1x6SExdCncsbRb3XMUYyshXcPo5OIFxT81fvComNJjkc/edit?usp=sharing
+members:
+  - "[Aidan Doherty](https://thegooddocs.slack.com/team/U019868JEQ0)"
+  - "[Alyssa Rock](https://thegooddocs.slack.com/team/U012KCMPP0V)"
+  - "[Bryan Klein](https://thegooddocs.slack.com/team/U018BJR6JQN)"
+  - "[Cameron Shorter](https://thegooddocs.slack.com/team/UKTGLQNGG)"
+  - "[Carrie Crowe](https://thegooddocs.slack.com/team/U01QS8YAHHN)"
+  - "[Ryan Macklin](https://thegooddocs.slack.com/team/U01DYRWG43X)"
+draft: false
+---
+
+The Content Strategy working group ensures that the content on our various communication channels supports our project's objectives and meets the needs of our contributors, users, and followers.
+
+This group's will work on defining users by monitoring site analytics or conducting user research, defining who will help create content and how, and develop our content lifecycle.
+
+Join this group if you are interested in user research, social media, and high-level discussions about content strategy!


### PR DESCRIPTION
This PR adds the new Content Strategy working group to the website.