### PR TITLE
Fix the group description for the Content Strategy WG

### DIFF
--- a/content/en/working-group/content-strategy.md
+++ b/content/en/working-group/content-strategy.md
@@ -3,7 +3,7 @@ title: Content Strategy
 poc: "[Carrie Crowe](https://thegooddocs.slack.com/team/U01QS8YAHHN)"
 meeting: TBD
 status: Active
-description: Creating
+description: Collaborating to create the overall content strategy for the Good Docs project.
 slackName: content-strategy
 slackID: C023G344YAJ
 notesURL: https://docs.google.com/document/d/1x6SExdCncsbRb3XMUYyshXcPo5OIFxT81fvComNJjkc/edit?usp=sharing


### PR DESCRIPTION
I realized the other day that the description for the Content Strategy group is incomplete and this PR is intended to fix it.