### PR TITLE
Typo fix and line ending changes for COC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,176 +2,98 @@
 
 `Version 0.2 - Last updated February 2021`
 
-The Good Docs Project and its members, contributors, sponsors, and leaders
-pledge to make participation in our community a positive, inclusive, and safe
-experience for all. The Good Docs Project encourages contributions from everyone
-who shares our goals and wants to participate in a healthy, constructive, and
-professional manner.
+The Good Docs Project and its members, contributors, sponsors, and leaders pledge to make participation in our community a positive, inclusive, and safe experience for all.
+The Good Docs Project encourages contributions from everyone who shares our goals and wants to participate in a healthy, constructive, and professional manner.
 
-This code of conduct aims to support a community where all people should feel
-safe to participate, to introduce new ideas, and to inspire others. This
-includes everyone, regardless of: ability, age, background, body size or type,
-caste, disability (either visible or invisible), education, ethnicity, family
-status, gender, gender identity and expression, geographic location, level of
-experience, marital status, nationality or national origin, native language,
-personal appearance, race, religion, sexual identity and orientation,
-socio-economic status, or any other dimension of diversity.
+This code of conduct aims to support a community where all people should feel safe to participate, to introduce new ideas, and to inspire others.
+This includes everyone, regardless of: ability, age, background, body size or type, caste, disability (either visible or invisible), education, ethnicity, family status, gender, gender identity and expression, geographic location, level of
+experience, marital status, nationality or national origin, native language, personal appearance, race, religion, sexual identity and orientation, socio-economic status, or any other dimension of diversity.
 
 Openness and respectful collaboration are core values at the Good Docs Project.
-We are committed to being a community that everyone feels good about joining,
-and we will always work to treat everyone well. No matter how you identify
-yourself or how others perceive you, you are welcome. We gain strength from
-diversity and actively seek participation from those who enhance it.
+We are committed to being a community that everyone feels good about joining, and we will always work to treat everyone well. No matter how you identify yourself or how others perceive you, you are welcome.
+We gain strength from diversity and actively seek participation from those who enhance it.
 
-These guidelines exist to enable all Good Docs community members to collaborate
-effectively. As such, this document outlines both expected behavior and behavior
-that will not be tolerated.
+These guidelines exist to enable all Good Docs community members to collaborate effectively.
+As such, this document outlines both expected behavior and behavior that will not be tolerated.
 
 ## Expected behavior
 
 We expect our members, contributors, and leaders to:
 
-- Participate in the community actively and authentically. Your meaningful
-  contributions add to the health and longevity of this community.
-- Attempt collaboration before conflict. Seek out and be respectful of differing
-  opinions, styles, viewpoints, and experiences.
-- Give and accept constructive feedback, gracefully. When expressing
-  disagreement, be professional and respectful. Be open to learning from and
-  educating others and educating others where needed.
-- Demonstrate empathy and kindness toward other people. Be considerate and
-  respectful in your word choice, speech, and actions. Show respect with the
-  terms you use to address others.
-- Look out for those around you in the community, especially if you are in a
-  position of influence. Alert [community moderators](Community_moderators.md)
-  if you notice a dangerous situation, someone in distress, or violations of
-  this code of conduct, even if they seem inconsequential.
-- Gracefully accept responsibility and apologize to those affected by any
-  mistakes, whether made intentionally or unintentionally. If someone says they
-  have been harmed through your words or actions, listen carefully, make amends,
-  learn from the experience, and correct the behavior going forward.
-- Focus on what is best for the overall community, not just for us as
-  individuals. Ensure that leadership roles and opportunities are
-  well-distributed across the community membership and not just centered in one
-  person or the same few people. To help our community develop and build up
-  leaders at every level of the Good Docs Project, ensure that you share
-  knowledge with others as much as possible and be mindful of fostering healthy
-  dialogue where no one voice dominates a conversation.
+- Participate in the community actively and authentically. Your meaningful contributions add to the health and longevity of this community.
+- Attempt collaboration before conflict. Seek out and be respectful of differing opinions, styles, viewpoints, and experiences.
+- Give and accept constructive feedback, gracefully. When expressing disagreement, be professional and respectful. Be open to learning from and educating others where needed.
+- Demonstrate empathy and kindness toward other people. Be considerate and respectful in your word choice, speech, and actions. Show respect with the terms you use to address others.
+- Look out for those around you in the community, especially if you are in a position of influence. Alert [community moderators](Community_moderators.md) if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
+- Gracefully accept responsibility and apologize to those affected by any mistakes, whether made intentionally or unintentionally. If someone says they have been harmed through your words or actions, listen carefully, make amends, learn from the experience, and correct the behavior going forward.
+- Focus on what is best for the overall community, not just for us as individuals. Ensure that leadership roles and opportunities are well-distributed across the community membership and not just centered in one person or the same few people. To help our community develop and build up leaders at every level of the Good Docs Project, ensure that you share knowledge with others as much as possible and be mindful of fostering healthy dialogue where no one voice dominates a conversation.
 
 ## Behavior that will not be tolerated
 
-The following behaviors are unacceptable within our community, whether they
-occur online, offline, privately, or publicly:
+The following behaviors are unacceptable within our community, whether they occur online, offline, privately, or publicly:
 
 - Violent threats or language directed against another person.
 - Sexist, racist, or otherwise discriminatory jokes and language.
 - Deliberate intimidation, stalking, or following (online or in person).
-- Personal insults, especially those related to gender, sexual orientation,
-  race, religion, or disability. This includes misgendering, name calling, and
-  mockery.
-- Trolling (posting controversial comments in order to provoke others),
-  insulting, or making derogatory comments.
-- The use of sexualized language, jokes, or imagery, and sexual attention,
-  inappropriate physical contact, or sexual advances of any kind.
-- Bullying, tone-policing (attacking a person’s tone rather than the content of
-  their message), or repeatedly dominating a topic of conversation (such as
-  regularly talking over another person or not inviting discussion from others
-  where appropriate).
-- Publishing or threatening to publish others’ private information without their
-  explicit permission. Private information includes physical addresses, email
-  addresses, and emails or other communications sent privately or non-publicly.
+- Personal insults, especially those related to gender, sexual orientation, race, religion, or disability. This includes misgendering, name calling, and mockery.
+- Trolling (posting controversial comments in order to provoke others), insulting, or making derogatory comments.
+- The use of sexualized language, jokes, or imagery, and sexual attention, inappropriate physical contact, or sexual advances of any kind.
+- Bullying, tone-policing (attacking a person’s tone rather than the content of their message), or repeatedly dominating a topic of conversation (such as regularly talking over another person or not inviting discussion from others where appropriate).
+- Publishing or threatening to publish others’ private information without their explicit permission. Private information includes physical addresses, email addresses, and emails or other communications sent privately or non-publicly.
 - Excessive or unnecessary profanity.
-- Sustained disruption of community events, including meetings and
-  presentations.
-- Recording or photography at community meetings and events without explicit
-  permission.
+- Sustained disruption of community events, including meetings and presentations.
+- Recording or photography at community meetings and events without explicit permission.
 - Advocating for, or encouraging, any of the above behavior.
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
 
 ## Consequences of unacceptable behavior
 
-Unacceptable behavior from any Good Docs Project community member, contributor,
-sponsors, or leaders will not be tolerated. We expect everyone to comply with
-requests to stop unacceptable behavior immediately.
+Unacceptable behavior from any Good Docs Project community member, contributor, sponsors, or leaders will not be tolerated.
+We expect everyone to comply with requests to stop unacceptable behavior immediately.
 
-If a community member engages in unacceptable behavior, any community member or
-moderator should report the incident to the Good Docs Project community
-moderators. The moderators will investigate the incident to determine the
-incident’s severity and overall impact to the community. Depending on the risk
-and impact level, the moderators may respond by requiring:
+If a community member engages in unacceptable behavior, any community member or moderator should report the incident to the Good Docs Project community moderators.
+The moderators will investigate the incident to determine the incident’s severity and overall impact to the community. Depending on the risk and impact level, the moderators may respond by requiring:
 
-- **Correction:** A private, written warning from community moderators,
-  providing clarity around the nature of the violation and an explanation of why
-  the behavior was inappropriate and what behavior is expected going forward. A
-  public apology may be requested.
-- **Warning:** A warning with consequences for continued behavior. No
-  interaction with the people involved, including unsolicited interaction with
-  community moderators, for a specified period of time. This includes avoiding
-  interactions in community spaces as well as external channels like social
-  media. Violating these terms may lead to a temporary or permanent ban.
-- **Temporary ban:** A temporary ban from any sort of interaction or public
-  communication with the community for a specified period of time. No public or
-  private interaction with the people involved, including unsolicited
-  interaction with community moderators, is allowed during this period.
-  Violating these terms may lead to a permanent ban. Readmittance to the
-  community usually requires an additional meeting with a community moderator to
-  ensure future compliance.
-- **Permanent ban:** A permanent ban from any sort of public interaction within
-  the community.
+- **Correction:** A private, written warning from community moderators, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate and what behavior is expected going forward. A public apology may be requested.
+- **Warning:** A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with community moderators, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+- **Temporary ban:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with community moderators, is allowed during this period. Violating these terms may lead to a permanent ban. Readmittance to the community usually requires an additional meeting with a community moderator to ensure future compliance.
+- **Permanent ban:** A permanent ban from any sort of public interaction within the community.
 
 ## Reporting an incident
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to one of the Good Docs Project
-[community moderators](Community_moderators.md). If you would like to discuss
-your concerns or if you have personally experienced unacceptable behavior,
-please reach out to a community moderator as soon as possible. Please report all
-violations of these guidelines, even if the situation is not happening to you.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to one of the Good Docs Project
+[community moderators](Community_moderators.md).
+If you would like to discuss your concerns or if you have personally experienced unacceptable behavior, please reach out to a community moderator as soon as possible.
+Please report all violations of these guidelines, even if the situation is not happening to you.
 
 ## Addressing code of conduct reports
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to one of the Good Docs Project community moderators. See
-[community moderators](Community_moderators.md) for a list of the current
-moderators. All complaints will be reviewed and investigated promptly and
-fairly. If possible, community moderators will recuse themselves in cases where
-there is a conflict of interest.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to one of the Good Docs Project community moderators.
+See [community moderators](Community_moderators.md) for a list of the current moderators.
+All complaints will be reviewed and investigated promptly and fairly.
+If possible, community moderators will recuse themselves in cases where there is a conflict of interest.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident. In some cases, community moderators may determine that
-a public statement will need to be made. If that's the case, the identities of
-all victims and reporters will remain confidential unless those individuals
-instruct us otherwise.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+In some cases, community moderators may determine that a public statement will need to be made.
+If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
 
-If you feel you have been unfairly accused of violating these guidelines, please
-follow the same reporting process to request an appeal.
+If you feel you have been unfairly accused of violating these guidelines, please follow the same reporting process to request an appeal.
 
 ## Scope
 
-These guidelines apply to all members of the Good Docs Project and to all Good
-Docs Project activities, including but not limited to:
+These guidelines apply to all members of the Good Docs Project and to all Good Docs Project activities, including but not limited to:
 
 - Representing the Good Docs Project at public events and in social media.
-- Participating in the Good Docs Project meetings and events, whether virtual or
-  in person.
-- Participating in the Good Docs Project’s related messaging forums, including
-  our Slack workspace and mailing list and other Good Docs Project-related
-  correspondence.
-- Interpersonal communications between Good Docs Project community members,
-  whether virtual or in person.
+- Participating in the Good Docs Project meetings and events, whether virtual or in person.
+- Participating in the Good Docs Project’s related messaging forums, including our Slack workspace and mailing list and other Good Docs Project-related correspondence.
+- Interpersonal communications between Good Docs Project community members, whether virtual or in person.
 
-While this code of conduct applies specifically to the Good Docs Project’s work
-and community, it is possible for actions taken outside of the Good Docs
-Project’s online or in-person spaces to have a deep impact on community health
-if it concerns the Good Docs Project or its members in some way. The code of
-conduct moderators reserve the right to consider communications or actions that
-occur outside of official Good Docs Project spaces if they have a demonstrated
-impact on one or more community members.
+While this code of conduct applies specifically to the Good Docs Project’s work and community, it is possible for actions taken outside of the Good Docs Project’s online or in-person spaces to have a deep impact on community health if it concerns the Good Docs Project or its members in some way.
+The code of conduct moderators reserve the right to consider communications or actions that occur outside of official Good Docs Project spaces if they have a demonstrated impact on one or more community members.
 
 ## Resources
 
-In creating this code of conduct, the authors adapted or were inspired by the
-following resources, listed alphabetically:
+In creating this code of conduct, the authors adapted or were inspired by the following resources, listed alphabetically:
 
 - [Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/)
 - [Apache Foundation Code of Conduct](http://www.apache.org/foundation/policies/conduct#code-of-conduct)


### PR DESCRIPTION
## Purpose / why

I am working on a Code of Conduct template and so I was reviewing our existing CoC guidelines. In the process of reviewing those guidelines, I noticed a few small errors that needed to be fixed.

## What changes were made?

No major changes have been to the text that alters its meaning in any way. The changes made are:

- Small typographical error corrections
- Changing the line endings to match Bryan's preferred standard of having 1 line per sentence or element as opposed to inserting hard line returns at an arbitrary point.