### PR TITLE
Issue #117: Added link to Roles page from the Who We Are page

### DIFF
--- a/content/en/who-we-are.md
+++ b/content/en/who-we-are.md
@@ -1,11 +1,11 @@
 ---
 title: Who We Are
-
 ---
 
 {{% blocks/lead color="primary" %}}
 
 # Who We Are
+
 Here we list the people behind this project, as defined by the project's [roles](/roles).
 
 {{% /blocks/lead %}}
@@ -14,58 +14,60 @@ Here we list the people behind this project, as defined by the project's [roles]
 
 The Good Docs Project Project Steering Committee (PSC) is the official managing body of The Good Docs Project and is responsible for setting overall project direction.
 The committee is drawn from The Good Docs Project community and is based on merit and interest.
+For more information about what these roles and responsibilities mean, see [Roles and responsibilities](/roles).
 
 ## PSC Members
 
--   Alyssa Rock, chair
--   Aaron Peters
--   Ankita Tripathi
--   Bryan Klein
--   Cameron Shorter
--   Carrie Crowe
--   Deanna Thompson
--   Erin McKean
--   Felicity Brand
--   Gayathri Krishnaswamy
--   Morgan Craft
--   Nelson Guya
--   Ryan Macklin
--   Viraji Ogodapola
+- Alyssa Rock, chair
+- Aaron Peters
+- Ankita Tripathi
+- Bryan Klein
+- Cameron Shorter
+- Carrie Crowe
+- Deanna Thompson
+- Erin McKean
+- Felicity Brand
+- Gayathri Krishnaswamy
+- Morgan Craft
+- Nelson Guya
+- Ryan Macklin
+- Viraji Ogodapola
 
 Our thanks to previous PSC members:
 
--   Aidan Doherty
--   Becky Todd
--   Clarence Cromwell
--   Jared Morgan
--   Jennifer Rondeau
--   Jo Cook
+- Aidan Doherty
+- Becky Todd
+- Clarence Cromwell
+- Jared Morgan
+- Jennifer Rondeau
+- Jo Cook
 
 ## Committers
 
--   Chris Ward
--   Clarence Cromwell
--   Daniel Beck
--   Derek Ardolf
--   Felicity Brand
--   Jared Morgan
--   Lana Brindley
+- Chris Ward
+- Clarence Cromwell
+- Daniel Beck
+- Derek Ardolf
+- Felicity Brand
+- Jared Morgan
+- Lana Brindley
 
 PSC members may retire any time. If a PSC member becomes inactive, for multiple quarters, it may be time to retire. (Ex-members will typically be welcomed back if they become active again.) An inactive member may be invited to retire. If unresponsive they may be removed by the existing PSC.
 
 ## Mentors
+
 Informal and semi-formal mentoring is a natural part of our community which we encourage and enjoy.
 Here we list formal mentoring which has been set up as part of our [proposal selection](/proposal-selection) process:
 
-* Jared Morgan
-* Clarence Cromwell
+- Jared Morgan
+- Clarence Cromwell
 
 Our thanks to previous mentors:
 
-* \<None yet\>
+- \<None yet\>
 
 ## Treasurers
 
-* \<Still to be officially endorsed\>
+- \<Still to be officially endorsed\>
 
 {{% /blocks/section %}}


### PR DESCRIPTION
I added a link to the Roles page in the introductory paragraph of the Who We Are page. (Issue #117)