### PR TITLE
Update Slack join link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -88,13 +88,13 @@ logo = "/images/logo.png"
 # This menu appears only if you have at least one [params.versions] set.
 version_menu = "Releases"
 
-# Flag used in the "version-banner" partial to decide whether to display a 
+# Flag used in the "version-banner" partial to decide whether to display a
 # banner on every page indicating that this is an archived version of the docs.
 # Set this flag to "true" if you want to display the banner.
 archived_version = false
 
 # The version number for the version of the docs represented in this doc set.
-# Used in the "version-banner" partial to display a version number for the 
+# Used in the "version-banner" partial to display a version number for the
 # current doc set.
 version = "0.0"
 
@@ -147,7 +147,7 @@ yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/i
 no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.
-# If you want this feature, but occasionally need to remove the Reading time from a single page, 
+# If you want this feature, but occasionally need to remove the Reading time from a single page,
 # add "hide_readingtime: true" to the page's front matter
 [params.ui.readingtime]
 enable = false
@@ -183,6 +183,6 @@ enable = false
   desc = "Chat with other project members."
 [[params.links.developer]]
 	name = "Slack Join Link"
-	url = "https://join.slack.com/t/thegooddocs/shared_invite/enQtODkyNjI5MDc0NjE0LTUyNGFiZmU1MjIzNDMwN2E3NmQwODQwZmRkYWI5MDhlMzdjYzg4Nzg4YjM3ODA0NGE4MTgyYzdkMGViMTI2MDM"
+	url = "https://join.slack.com/t/thegooddocs/shared_invite/zt-be2gay0m-Ukq_5SI0MHp20IQP3auQjg"
 	icon = "fab fa-slack"
   desc = "To join The Good Docs Project Slack Workspace."

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -27,7 +27,7 @@ For that reason, one of the best ways you can get started is to look at our [lis
 
 Once you find a group that is working on a project that interests you:
 
-* Join our [Slack workspace](https://join.slack.com/t/thegooddocs/shared_invite/enQtODkyNjI5MDc0NjE0LTUyNGFiZmU1MjIzNDMwN2E3NmQwODQwZmRkYWI5MDhlMzdjYzg4Nzg4YjM3ODA0NGE4MTgyYzdkMGViMTI2MDM) and add yourself to the channel for the working group you want to join.
+* Join our [Slack workspace](https://join.slack.com/t/thegooddocs/shared_invite/zt-be2gay0m-Ukq_5SI0MHp20IQP3auQjg) and add yourself to the channel for the working group you want to join.
 * Most working groups meet on a regular basis (either weekly, every other week, or monthly). Check the meeting times for that group and our Google calendar for meeting details.
 
 We also have general meetings where you can come and meet the project leaders and learn more about the project.
@@ -38,7 +38,7 @@ When engaging with members of our project, we ask that you follow our [Code of C
 
 ### Slack
 
-We often chat in Slack. You can join [our Slack workspace](https://join.slack.com/t/thegooddocs/shared_invite/enQtODkyNjI5MDc0NjE0LTUyNGFiZmU1MjIzNDMwN2E3NmQwODQwZmRkYWI5MDhlMzdjYzg4Nzg4YjM3ODA0NGE4MTgyYzdkMGViMTI2MDM).
+We often chat in Slack. You can join [our Slack workspace](https://join.slack.com/t/thegooddocs/shared_invite/zt-be2gay0m-Ukq_5SI0MHp20IQP3auQjg).
 
 The main channels are:
 


### PR DESCRIPTION
This PR updates the Slack Join link to one that I generated as opposed to one that Cameron generated. This way, it will notify me when someone joins from the website rather than Cameron. (Cameron is having difficulties keeping up with the number of new community members.)