### PR TITLE
Update link on home page to latest release. (#184)

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -45,7 +45,7 @@ Our key target audiences are:
 ## Download
 
 * The latest development version of templates is available from the [github main branch](https://github.com/thegooddocsproject/templates).
-* The [0.2 (Alamillo) release of templates](https://github.com/thegooddocsproject/templates/releases/tag/v0.2.0) was released at the 2022 Write The Docs Portland conference.
+* The [0.2 (Alamillo) template suite](https://github.com/thegooddocsproject/templates/releases/tag/v0.2.0) was released at the 2022 Write The Docs Portland conference.
 
 ## 2022 Initiatives
 For a list of our current projects and initiatives, see our [2022 release goals](https://github.com/thegooddocsproject/governance/wiki/Write-The-Docs-Portland-2022-Release).


### PR DESCRIPTION
Fixes the template release link on the home page to use the latest.