### PR TITLE
404 sites: Clean up bad link

### DIFF
--- a/content/en/prioritization.md
+++ b/content/en/prioritization.md
@@ -1,6 +1,6 @@
 ---
 title: Prioritization Guidelines
-
+lastmod: 2022-07-02T00:22:40.584Z
 ---
 
 {{% blocks/lead color="primary" %}}
@@ -27,7 +27,7 @@ We prioritize the following principles when considering budget allocation:
 *   We are wary of introducing a maintenance liability. We want material which is going to be adopted and maintained by the greater community.
 *   We look favourably on matching contributions. If someone else is prepared to sponsor your idea, it is a good indicator of worthiness.
 *   We like to help owners of useful proprietary material who wish to share it under an open license. This could be by covering the business costs of sharing, or by counting the material as an in-kind contribution.
-*   The results of any implementation, and its dependencies, must be available under the [open licenses](/licences) used by our project.
+*   The results of any implementation, and its dependencies, must be available under the [open licenses](/licenses) used by our project.
 
 ## Sponsorship
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,7 +32,3 @@ to = "/docs/glossaries/roadmap/"
 from = "/docs/glossaries/primer/maturity-levels"
 to = "/docs/glossaries/maturity-levels/"
 
-[[redirects]]
-
-from = "/licences"
-to = "/licenses/"


### PR DESCRIPTION
I've cleaned up the link for the licenses. 
However, the other two URLs appeared as a 404 on a site crawling app, but I didn't find any matching bad links in our documents.